### PR TITLE
Add Android widget pinning support to WidgetBridgePlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,22 @@ Retrieves current widget configurations.
 
 **Since:** 7.0.0
 
+
+### requestWidget()
+
+```typescript
+requestWidget() => Promise<DataResults<boolean>>
+```
+Requests the user to pin the widget to their home screen.
+
+- iOS: Not supported (no equivalent functionality).
+- Android: Uses AppWidgetManager's `requestPinAppWidget` to prompt the user to add a widget.
+
+**Returns:** <code>Promise&lt;<a href="#dataresults">DataResults</a>&lt;boolean&gt;&gt;</code>
+
+**Since:** 7.0.0
+
+
 --------------------
 
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ Retrieves current widget configurations.
 
 **Since:** 7.0.0
 
+--------------------
+
 
 ### requestWidget()
 

--- a/android/src/main/java/de/kisimedia/plugins/widgetbridgeplugin/WidgetBridgePlugin.java
+++ b/android/src/main/java/de/kisimedia/plugins/widgetbridgeplugin/WidgetBridgePlugin.java
@@ -189,8 +189,18 @@ public class WidgetBridgePlugin extends Plugin {
             } else {
                 call.reject("Pinning not supported");
             }
+        } catch (ClassNotFoundException e) {
+            call.reject("Error: Widget provider class not found: " + e.getMessage());
+            e.printStackTrace();
+        } catch (IllegalArgumentException e) {
+            call.reject("Error: Invalid argument: " + e.getMessage());
+            e.printStackTrace();
+        } catch (NullPointerException e) {
+            call.reject("Error: Null pointer encountered: " + e.getMessage());
+            e.printStackTrace();
         } catch (Exception e) {
-            call.reject("Error: " + e.getMessage());
+            call.reject("Unexpected error: " + e.getMessage());
+            e.printStackTrace();
         }
     }
 

--- a/android/src/main/java/de/kisimedia/plugins/widgetbridgeplugin/WidgetBridgePlugin.java
+++ b/android/src/main/java/de/kisimedia/plugins/widgetbridgeplugin/WidgetBridgePlugin.java
@@ -154,10 +154,14 @@ public class WidgetBridgePlugin extends Plugin {
         call.resolve(new JSObject().put("results", "not supported"));
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
     @PluginMethod
     public void requestWidget(PluginCall call) {
         Context context = getContext();
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            call.reject("This feature requires Android O (API level 26) or higher.");
+            return;
+        }
 
         if (registeredWidgetProviders.length == 0) {
             call.reject("No registered widget provider");

--- a/android/src/main/java/de/kisimedia/plugins/widgetbridgeplugin/WidgetBridgePlugin.java
+++ b/android/src/main/java/de/kisimedia/plugins/widgetbridgeplugin/WidgetBridgePlugin.java
@@ -180,7 +180,8 @@ public class WidgetBridgePlugin extends Plugin {
                         context,
                         0,
                         pinnedWidgetCallbackIntent,
-                        PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE
+                        PendingIntent.FLAG_UPDATE_CURRENT | 
+                        (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_MUTABLE : PendingIntent.FLAG_IMMUTABLE)
                 );
 
                 appWidgetManager.requestPinAppWidget(myWidgetProvider, null, successCallback);

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -80,6 +80,18 @@ export interface WidgetBridgePlugin {
    * @returns {Promise<DataResults<any>>} Promise resolving to configuration data.
    */
   getCurrentConfigurations(): Promise<DataResults<any>>;
+
+  /**
+   * Requests the user to pin the widget to their home screen.
+   *
+   * - iOS: Not supported (no equivalent functionality).
+   * - Android: Uses AppWidgetManager's `requestPinAppWidget` to prompt the user to add a widget.
+   * 
+   *
+   * @since 7.0.0
+   * @returns {Promise<void>} Promise that resolves when the request has been made.
+   */
+  requestWidget(): Promise<DataResults<boolean>>;
 }
 
 export interface UserDefaultsOptions {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -89,7 +89,7 @@ export interface WidgetBridgePlugin {
    * 
    *
    * @since 7.0.0
-   * @returns {Promise<void>} Promise that resolves when the request has been made.
+   * @returns {Promise<DataResults<boolean>>} Promise that resolves when the request has been made.
    */
   requestWidget(): Promise<DataResults<boolean>>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,5 @@ import { registerPlugin } from '@capacitor/core';
 import { WidgetBridgePlugin } from './definitions';
 
 const WidgetBridgePlugin = registerPlugin<WidgetBridgePlugin>('WidgetBridgePlugin');
-
 export * from './definitions';
 export { WidgetBridgePlugin };


### PR DESCRIPTION
### Summary

This pull request adds support for requesting users to pin widgets to the home screen on Android 8.0+ using `AppWidgetManager.requestPinAppWidget`.

### Changes

- Added `requestWidget()` method in the native Android plugin
- Updated plugin interface in TypeScript to include documentation
- Used `PendingIntent` with appropriate API level checks (for `FLAG_MUTABLE`)
- Handles widget provider registration via `setRegisteredWidgets()`

### Platform support

- ✅ Android 8.0 (API 26) and above
- ❌ iOS not supported (platform does not support widget pinning)

### Usage

```ts
await WidgetBridgePlugin.setRegisteredWidgets({
  widgets: ['com.example.MyWidgetProvider']
});

await WidgetBridgePlugin.requestWidget();
